### PR TITLE
fix: include credentials in Brain app fetch calls

### DIFF
--- a/Brain/public/login.html
+++ b/Brain/public/login.html
@@ -212,6 +212,7 @@
                     headers: {
                         'Content-Type': 'application/json'
                     },
+                    credentials: 'include',
                     body: JSON.stringify({ uid })
                 });
 

--- a/Brain/public/script.js
+++ b/Brain/public/script.js
@@ -24,10 +24,10 @@ async function apiCall(endpoint, options = {}) {
             headers: {
                 'Content-Type': 'application/json',
             },
+            credentials: 'include',
         };
 
         // Session-based authentication - no need to manually add uid
-
         const response = await fetch(endpoint, { ...baseOptions, ...options });
         if (response.status === 401) {
             window.location.href = '/login.html';


### PR DESCRIPTION
## Summary
- send credentials with Brain login requests
- ensure API helper forwards cookies for session-based auth

## Testing
- `npm test --prefix Brain` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68961d1484ec8322b08770dcea7998e8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login and API request handling to ensure cookies and authentication information are properly included, enhancing session-based authentication reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->