### PR TITLE
fix: include credentials in Brain app fetch calls

### DIFF
--- a/Brain/public/login.html
+++ b/Brain/public/login.html
@@ -210,9 +210,10 @@
                 const response = await fetch('/api/auth/login', {
                     method: 'POST',
                     headers: {
-                        'Content-Type': 'application/json'
+                        'Content-Type': 'application/x-www-form-urlencoded'
                     },
-                    body: JSON.stringify({ uid })
+                    credentials: 'include',
+                    body: new URLSearchParams({ uid })
                 });
 
                 const data = await response.json();

--- a/Brain/public/script.js
+++ b/Brain/public/script.js
@@ -24,10 +24,10 @@ async function apiCall(endpoint, options = {}) {
             headers: {
                 'Content-Type': 'application/json',
             },
+            credentials: 'include',
         };
 
         // Session-based authentication - no need to manually add uid
-
         const response = await fetch(endpoint, { ...baseOptions, ...options });
         if (response.status === 401) {
             window.location.href = '/login.html';


### PR DESCRIPTION
## Summary
- send credentials with Brain login requests
- ensure API helper forwards cookies for session-based auth
- post login UID without JSON content type to bypass CORS preflight

## Testing
- `npm test --prefix Brain` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68961d1484ec8322b08770dcea7998e8