### PR TITLE
feat: add data reset option for lost encryption keys

### DIFF
--- a/Brain/public/login.html
+++ b/Brain/public/login.html
@@ -381,6 +381,9 @@
             </div>
             <button type="submit" class="login-btn">Login</button>
         </form>
+        <div style="margin-top: 20px; text-align: center;">
+            <a href="#" onclick="showResetOption(); return false;" style="color: rgba(255, 68, 68, 0.8); font-size: 14px; text-decoration: none;">Lost your encryption key? Reset data</a>
+        </div>
         <a href="/privacy.html" class="privacy-link">Privacy Policy</a>
     </div>
     <div class="version">v1.0.0</div>
@@ -459,6 +462,152 @@
             }
         });
 
+        async function showResetOption() {
+            const uid = document.getElementById('uid').value;
+            if (!uid) {
+                await Swal.fire({
+                    title: 'UID Required',
+                    text: 'Please enter your UID first',
+                    icon: 'info',
+                    confirmButtonColor: '#00ffaa',
+                    customClass: {
+                        popup: 'brain-auth-modal'
+                    }
+                });
+                document.getElementById('uid').focus();
+                return;
+            }
+            
+            const result = await Swal.fire({
+                title: '⚠️ Reset All Data?',
+                html: `
+                    <div style="text-align: left; padding: 20px; color: #ffffff;">
+                        <p><strong>This will permanently delete:</strong></p>
+                        <ul style="margin: 10px 0;">
+                            <li>All your memories and connections</li>
+                            <li>Your current encryption key</li>
+                            <li>All encrypted data</li>
+                        </ul>
+                        <p style="margin-top: 20px; color: #ff1493;">
+                            <strong>This action cannot be undone!</strong>
+                        </p>
+                        <p style="margin-top: 10px; color: #00ffaa;">
+                            You'll get a fresh start with a new encryption key.
+                        </p>
+                    </div>
+                `,
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#ff1493',
+                cancelButtonColor: '#00ffaa',
+                confirmButtonText: 'Yes, Reset Everything',
+                cancelButtonText: 'Cancel',
+                customClass: {
+                    popup: 'brain-auth-modal'
+                }
+            });
+            
+            if (result.isConfirmed) {
+                // Second confirmation - more serious tone
+                const finalConfirm = await Swal.fire({
+                    title: '🛑 FINAL CONFIRMATION',
+                    html: `
+                        <div style="text-align: center; padding: 20px; color: #ffffff;">
+                            <p style="font-size: 18px; color: #ff1493; font-weight: bold;">
+                                This action is IRREVERSIBLE
+                            </p>
+                            <p style="margin: 20px 0; font-size: 16px;">
+                                Type <strong style="color: #ff1493;">DELETE</strong> to confirm
+                            </p>
+                            <p style="color: rgba(255, 255, 255, 0.7); font-size: 14px;">
+                                All your memories, connections, and encrypted data will be permanently erased.
+                            </p>
+                        </div>
+                    `,
+                    input: 'text',
+                    inputPlaceholder: 'Type DELETE to confirm',
+                    inputValidator: (value) => {
+                        if (!value || value.toUpperCase() !== 'DELETE') {
+                            return 'Please type DELETE to confirm';
+                        }
+                    },
+                    icon: 'warning',
+                    showCancelButton: true,
+                    confirmButtonColor: '#ff1493',
+                    cancelButtonColor: '#666',
+                    confirmButtonText: 'Yes, Delete Everything',
+                    cancelButtonText: 'Cancel',
+                    customClass: {
+                        popup: 'brain-auth-modal'
+                    }
+                });
+                
+                if (!finalConfirm.isConfirmed) {
+                    return;
+                }
+                
+                try {
+                    // First login to get session
+                    const loginResponse = await fetch('/api/auth/login', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                        credentials: 'include',
+                        body: JSON.stringify({ uid })
+                    });
+                    
+                    if (!loginResponse.ok) {
+                        throw new Error('Failed to authenticate');
+                    }
+                    
+                    // Now reset the data
+                    const response = await fetch('/api/reset-data', {
+                        method: 'POST',
+                        credentials: 'include',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        }
+                    });
+                    
+                    if (response.ok) {
+                        // Clear any local storage
+                        localStorage.clear();
+                        // Clear cookies
+                        document.cookie.split(";").forEach(c => {
+                            document.cookie = c.replace(/^ +/, "").replace(/=.*/, "=;expires=" + new Date().toUTCString() + ";path=/");
+                        });
+                        
+                        await Swal.fire({
+                            title: 'Data Reset Complete',
+                            text: 'You can now login again to start fresh with a new encryption key.',
+                            icon: 'success',
+                            confirmButtonColor: '#00ffaa',
+                            customClass: {
+                                popup: 'brain-auth-modal'
+                            }
+                        });
+                        
+                        // Reload the page
+                        window.location.reload();
+                    } else {
+                        throw new Error('Reset failed');
+                    }
+                } catch (error) {
+                    console.error('Reset error:', error);
+                    Swal.fire({
+                        title: 'Reset Failed',
+                        text: 'Unable to reset data. Please try again or contact support.',
+                        icon: 'error',
+                        confirmButtonColor: '#ff1493',
+                        customClass: {
+                            popup: 'brain-auth-modal'
+                        }
+                    });
+                }
+            }
+        }
+        
         async function handleLogin(event) {
             event.preventDefault();
             const uid = document.getElementById('uid').value.trim();

--- a/Brain/public/login.html
+++ b/Brain/public/login.html
@@ -571,12 +571,27 @@
                     });
                     
                     if (response.ok) {
-                        // Clear any local storage
-                        localStorage.clear();
-                        // Clear cookies
-                        document.cookie.split(";").forEach(c => {
-                            document.cookie = c.replace(/^ +/, "").replace(/=.*/, "=;expires=" + new Date().toUTCString() + ";path=/");
-                        });
+                        // Clear client-side state (not HttpOnly session cookies)
+                        function cleanClientState() {
+                            try {
+                                // Clear local and session storage
+                                localStorage.clear();
+                                sessionStorage.clear();
+                                
+                                // Clear non-HttpOnly cookies (session cookie is cleared server-side)
+                                document.cookie.split(';').forEach(raw => {
+                                    const name = raw.split('=')[0].trim();
+                                    if (name) {
+                                        document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+                                    }
+                                });
+                            } catch (e) {
+                                console.warn('Client cleanup error:', e);
+                            }
+                        }
+                        
+                        // Clean up client state
+                        cleanClientState();
                         
                         await Swal.fire({
                             title: 'Data Reset Complete',

--- a/Brain/reset-user-data-procedure.sql
+++ b/Brain/reset-user-data-procedure.sql
@@ -1,0 +1,35 @@
+-- Stored procedure for atomic user data reset
+-- This ensures all operations happen together or not at all
+
+CREATE OR REPLACE FUNCTION public.reset_user_data(p_uid TEXT)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+    -- Ensure predictable search_path for SECURITY DEFINER
+    PERFORM set_config('search_path', 'public', true);
+    
+    -- Order matters if you don't have ON DELETE CASCADE:
+    -- Delete relationships first (they reference nodes)
+    DELETE FROM brain_relationships WHERE uid = p_uid;
+    
+    -- Then delete nodes
+    DELETE FROM brain_nodes WHERE uid = p_uid;
+    
+    -- Finally reset user's encryption key status
+    UPDATE brain_users 
+    SET 
+        code_check = NULL,
+        has_key = false
+    WHERE uid = p_uid;
+    
+    -- If no rows were updated (user doesn't exist), that's okay
+    -- The function will complete successfully
+END;
+$$;
+
+-- Revoke execute from public roles, only allow through API server
+REVOKE EXECUTE ON FUNCTION public.reset_user_data(TEXT) FROM anon, authenticated;
+-- If you need authenticated users to call it directly, uncomment:
+-- GRANT EXECUTE ON FUNCTION public.reset_user_data(TEXT) TO authenticated;

--- a/Brain/reset-user-data-procedure.sql
+++ b/Brain/reset-user-data-procedure.sql
@@ -12,10 +12,10 @@ BEGIN
     
     -- Order matters if you don't have ON DELETE CASCADE:
     -- Delete relationships first (they reference nodes)
-    DELETE FROM brain_relationships WHERE uid = p_uid;
-    
+    DELETE FROM memory_relationships WHERE uid = p_uid;
+
     -- Then delete nodes
-    DELETE FROM brain_nodes WHERE uid = p_uid;
+    DELETE FROM memory_nodes WHERE uid = p_uid;
     
     -- Finally reset user's encryption key status
     UPDATE brain_users 

--- a/Brain/server.js
+++ b/Brain/server.js
@@ -562,6 +562,45 @@ app.post('/api/code-check', requireAuth, async (req, res) => {
     }
 });
 
+// Reset user data endpoint - allows starting fresh with new key
+app.post('/api/reset-data', requireAuth, async (req, res) => {
+    try {
+        const uid = req.uid;
+        
+        // Delete all user's brain nodes
+        await supabase
+            .from('brain_nodes')
+            .delete()
+            .eq('uid', uid);
+        
+        // Delete all user's brain relationships
+        await supabase
+            .from('brain_relationships')
+            .delete()
+            .eq('uid', uid);
+        
+        // Reset user's encryption key status
+        await supabase
+            .from('brain_users')
+            .update({ 
+                code_check: null,
+                has_key: false 
+            })
+            .eq('uid', uid);
+        
+        // Clear session
+        req.session.destroy();
+        
+        res.json({ 
+            success: true, 
+            message: 'All data reset. Please login again to generate a new key.' 
+        });
+    } catch (error) {
+        console.error('Reset data error:', error);
+        res.status(500).json({ error: 'Failed to reset data' });
+    }
+});
+
 app.get("/setup", async (req, res) => {
     res.json({ 'is_setup_completed': true });
 });


### PR DESCRIPTION
- Add /api/reset-data endpoint to clear user data
- Add reset option on login page with double confirmation
- Requires typing DELETE to confirm data deletion
- Allows users to start fresh if encryption key is lost

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Lost your encryption key? Reset data” link on the login page with a guided two-step confirmation flow that requires your UID and typing "DELETE".
  * On final confirmation, the app briefly signs you in, triggers the reset, clears local storage/cookies, signs you out, shows success/failure, and reloads.

* **Backend**
  * New authenticated API endpoint and database routine to atomically remove a user’s data on request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
## EntelligenceAI PR Summary 
 Introduced a secure, user-initiated data reset feature:
- Added frontend UI and logic in Brain/public/login.html for data reset with confirmation flow
- Implemented backend POST '/api/reset-data' in Brain/server.js to delete user data and reset account state 

