### PR TITLE
fix: privacy policy back button goes to login instead of bypassing auth

### DIFF
--- a/Brain/public/privacy.html
+++ b/Brain/public/privacy.html
@@ -164,9 +164,9 @@
 
 <body>
     <div class="back-link">
-        <a href="/" class="back-btn">
+        <a href="/login.html" class="back-btn">
             <span class="icon">←</span>
-            Back to App
+            Back to Login
         </a>
     </div>
     <div class="privacy-container">


### PR DESCRIPTION
- Prevents session bypass when navigating from privacy policy
- Ensures proper authentication flow in sandboxed environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Privacy page’s back navigation to return users to the Login page instead of the app home, reducing confusion when exiting Privacy.
  * Changed the button label to “Back to Login” for clearer intent.
  * Ensures a consistent flow during sign-in and aligns the privacy experience with authentication entry points.
  * No impact on layout, styling, or other content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
## EntelligenceAI PR Summary 
 This PR updates the privacy policy page navigation link.
- Changed back link destination to '/login.html' in Brain/public/privacy.html
- Updated link text to 'Back to Login' 

